### PR TITLE
replaced the broken link for ChannelGroupTabMVC

### DIFF
--- a/msteams-platform/tabs/quickstarts/create-channel-group-tab-dotnet-core-mvc.md
+++ b/msteams-platform/tabs/quickstarts/create-channel-group-tab-dotnet-core-mvc.md
@@ -13,7 +13,7 @@ In this quickstart we'll walk-through creating a custom channel/group tab with C
 
 ## Get the source code
 
-Open a command prompt and create a new directory for your tab project. We have provided a simple [Channel Group Tab](https://github.com/OfficeDev/microsoft-teams-sample-tabs/ChannelGroupTabMVC) project to get you started. To retrieve the source code you can download the zip folder and extract the files or clone the sample repository into your new directory:
+Open a command prompt and create a new directory for your tab project. We have provided a simple [Channel Group Tab](https://github.com/OfficeDev/microsoft-teams-sample-tabs/tree/master/ChannelGroupTabMVC) project to get you started. To retrieve the source code you can download the zip folder and extract the files or clone the sample repository into your new directory:
 
 ```bash
 git clone https://github.com/OfficeDev/microsoft-teams-sample-tabs.git


### PR DESCRIPTION
Changed from https://github.com/OfficeDev/microsoft-teams-sample-tabs/ChannelGroupTabMVC to https://github.com/OfficeDev/microsoft-teams-sample-tabs/tree/master/ChannelGroupTabMVC